### PR TITLE
Fix AppInfo 'description' field

### DIFF
--- a/src/Provider/GoogleProvider.php
+++ b/src/Provider/GoogleProvider.php
@@ -53,7 +53,7 @@ class GoogleProvider extends CurlProvider
 
         $name = $crawler->filterXpath("descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' document-title ')]/descendant::div")->text();
         $owner = $crawler->filterXpath("descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' document-subtitle ') and (contains(concat(' ', normalize-space(@class), ' '), ' primary '))]/descendant::span")->text();
-        $description = $crawler->filterXpath("descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' id-app-orig-desc ')]")->text();
+        $description = $crawler->filterXpath('//*[@id="body-content"]/div/div/div[1]/div[1]/div/div[3]/div[1]/div[1]/div/div[1]')->text();
         $screenshots = $crawler->filterXpath("descendant-or-self::*[contains(concat(' ', normalize-space(@class), ' '), ' details-section ') and (contains(concat(' ', normalize-space(@class), ' '), ' screenshots '))]/descendant::*[contains(concat(' ', normalize-space(@class), ' '), ' screenshot-container ')]/descendant::img")->each(function ($node, $i) {
             if (0 === $i) {
                 return;


### PR DESCRIPTION
Fixes a bug in GoogleProvider which returns **InvalidArgumentException: The current node list is empty.** when trying to crawl for description's field content.
